### PR TITLE
버그 수정(페이즈 관련 URL 접속 버그, 참여자 목록 타원형 UI 버그), QnA 페이지 질문 로딩화면 추가

### DIFF
--- a/frontend/src/hooks/useParticipants.ts
+++ b/frontend/src/hooks/useParticipants.ts
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
 
 import { useSocketStore, useParticipantsStore } from '@/stores';
 import { ParticipantItem } from '@/types';

--- a/frontend/src/hooks/useParticipants.ts
+++ b/frontend/src/hooks/useParticipants.ts
@@ -47,7 +47,15 @@ const useParticipants = (roomId: string | null, finishInitialLoading: () => void
   const handleParticipantExit = (Participant: { participantId: string; nickname: string }) => {
     setParticipants((prev) => {
       const newParticipants = { ...prev };
+      const deletedIndex = newParticipants[Participant.participantId].index;
       delete newParticipants[Participant.participantId];
+      // 퇴장한 참여자 index보다 뒤의 참여자들 index 재조정
+      Object.keys(newParticipants).forEach((key) => {
+        if (newParticipants[key].index > deletedIndex) {
+          newParticipants[key].index -= 1;
+        }
+      });
+
       return newParticipants;
     });
   };

--- a/frontend/src/routes/components/room/RoomCreateButton.tsx
+++ b/frontend/src/routes/components/room/RoomCreateButton.tsx
@@ -27,11 +27,9 @@ const RoomCreateButton = () => {
         const roomUrl = new URL(response.url);
         if (roomUrl) navigate(roomUrl.pathname);
       } else {
-        console.error('Failed to create room');
         openToast({ text: '서버와 통신 중 에러가 발생했습니다!', type: 'error' });
       }
-    } catch (error) {
-      console.error('Error creating room:', error);
+    } catch {
       openToast({ text: '서버와 통신 중 에러가 발생했습니다!', type: 'error' });
     } finally {
       setLoading(false);

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -19,33 +19,6 @@ const router = createBrowserRouter([
   {
     path: '/rooms/:roomId',
     element: <RoomLayout />,
-    // loader: async ({ params }) => {
-    //   const { roomId } = params;
-    //   const socket = io(config.SOCKET_SERVER_URL);
-    //   socket.emit(
-    //     'join',
-    //     { roomId },
-    //     (response: { status: string; body: { participants: ParticipantItem[]; hostId: string } }) => {
-    //       const roomExists = response.status === 'ok';
-    //       if (roomExists) {
-    //         // 참가자 목록에 index 추가
-    //         const participantsWithIndex = response.body.participants.map((participant, index) => ({
-    //           ...participant,
-    //           index
-    //         }));
-
-    //         setParticipants(convertArrayToObject(participantsWithIndex));
-    //         setHostId(response.body.hostId);
-    //         finishInitialLoading();
-    //         // navigate(`/rooms/${params.roomId}/join`);
-    //       } else {
-    //         // TODO: ErrorElement 표시
-    //       }
-    //       setCurrentUserId(socket?.id || null);
-    //     }
-    //   );
-    //   return {};
-    // },
     children: [
       {
         path: 'join',

--- a/frontend/src/routes/layouts/Room.tsx
+++ b/frontend/src/routes/layouts/Room.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { useEffect, useMemo } from 'react';
 import { useErrorBoundary } from 'react-error-boundary';
-import { Outlet, useNavigate, useParams } from 'react-router-dom';
+import { Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import useParticipants from '@/hooks/useParticipants';
 
@@ -24,6 +24,7 @@ const RoomLayout = () => {
   const { initialLoading, finishInitialLoading } = useLoadingState();
   const navigate = useNavigate();
   const params = useParams();
+  const locaton = useLocation();
 
   const { participants, hostId, currentUserId, roomExists } = useParticipants(roomId, finishInitialLoading);
   const { radius, setRadius, increaseRadius } = useRadiusStore();
@@ -78,11 +79,14 @@ const RoomLayout = () => {
 
   if (!roomExists) showBoundary(new Error(roomError.RoomNotFound));
 
+  // URL이 정확히 /rooms/:roomId 인 경우 join 페이지로 이동
   useEffect(() => {
     if (!initialLoading) {
-      navigate(`/rooms/${params.roomId}/join`);
+      if (location.pathname.endsWith(params.roomId)) {
+        navigate('join', { replace: true });
+      }
     }
-  }, [initialLoading, params.roomId]);
+  }, [initialLoading, params.roomId, locaton.pathname, navigate]);
 
   return (
     <>

--- a/frontend/src/routes/layouts/Room.tsx
+++ b/frontend/src/routes/layouts/Room.tsx
@@ -37,9 +37,8 @@ const RoomLayout = () => {
 
   const participantElements = useMemo(
     () =>
-      Object.keys(participants).map((participantId) => {
-        const index = participants[participantId]?.index || 0;
-        const position = positions[index];
+      Object.keys(participants).map((participantId, idx) => {
+        const position = positions[idx];
 
         return position ? (
           <UserProfile

--- a/frontend/src/routes/layouts/Room.tsx
+++ b/frontend/src/routes/layouts/Room.tsx
@@ -37,8 +37,9 @@ const RoomLayout = () => {
 
   const participantElements = useMemo(
     () =>
-      Object.keys(participants).map((participantId, idx) => {
-        const position = positions[idx];
+      Object.keys(participants).map((participantId) => {
+        const index = participants[participantId]?.index || 0;
+        const position = positions[index];
 
         return position ? (
           <UserProfile

--- a/frontend/src/routes/pages/QnA.tsx
+++ b/frontend/src/routes/pages/QnA.tsx
@@ -12,6 +12,8 @@ import { Question } from '@/types';
 import { getRemainingSeconds } from '@/utils';
 import TimerWorker from '@/workers/timerWorker.js?worker';
 
+import LoadingPage from './LoadingPage';
+
 const QnAPhaseView = () => {
   const { socket, connect } = useSocketStore();
   const { questions, setQuestions } = useQuestionsStore();
@@ -172,7 +174,9 @@ const QnAPhaseView = () => {
         />
       </div>
     </div>
-  ) : null;
+  ) : (
+    <LoadingPage loadingMessage="질문 리스트를 불러오고 있어요..." />
+  );
 };
 
 export default QnAPhaseView;


### PR DESCRIPTION
# ✅ 주요 작업
- [x] `/rooms/:roomId/questions`와 같은 페이즈 관련 URL에 접속했을 때 `/rooms/:roomId/join` 경로로 내비게이션되는 문제 해결

https://github.com/user-attachments/assets/808d5a23-90fd-4898-a1cb-3f8d9b2a8928



- [x] 한 명이 나간 경우 남은 참여자 수보다 한 명이 적게 화면에 표시되는 문제 해결

https://github.com/user-attachments/assets/2fd06a94-f4e6-40cd-a7dc-889b14eaf5ec


- [x] QnA 페이지에서 질문 목록을 불러오는 도중 로딩 페이지 추가

https://github.com/user-attachments/assets/014202ac-8224-49e7-8ebd-4255203a103b



# 📚 학습 키워드

# 💭 고민과 해결과정

# 📌 이슈 사항
- 방장이 `퇴장`하지 않고 `새로고침`한 경우 `exit` 메시지가 날아가서 방장이 위임되는데 이것이 맞는가?
- 빠르게 여러번 새로고침을 시도했을 때 참여자 수가 늘어나는 버그가 있는데, 짧은 시간동안 퇴장/재접속 요청이 많이 들어와서 중간에 `exit` 메시지가 누락(반대로 `join`이 한번 더 온 것일수도 있음)되는 것을 확인했습니다. 다만 시간이 지나면(아래 사진에선느 약 20초) 누락됐던 `exit`메시지가 다시 도착하고, 유저 퇴장 시 인덱스가 그대로 남아있던 로직을 고쳐서인지 이번엔 정상적으로 남은 인원수만큼 화면에 표시되는 것을 확인했습니다.

<img width="413" alt="image" src="https://github.com/user-attachments/assets/fc666015-6ad0-4bb4-b257-8b11a903295e" />

- QnA가 시작되고 나서는 링크로 방에 더 이상 들어갈 수 없는 건가요?
