### PR TITLE
각 페이지에서 재접속 시 다시 불러와야 할 데이터를 요청하고 처리하는 로직 추가

### DIFF
--- a/common/phases.ts
+++ b/common/phases.ts
@@ -1,0 +1,9 @@
+// enum value: URL Pathname
+export enum Phases {
+  Join = "join",
+  QnA = "questions",
+  Statistics = "statistics",
+  ContentShare = "content-share",
+}
+
+export type PhaseKeys = keyof typeof Phases;

--- a/frontend/src/hooks/useParticipants.ts
+++ b/frontend/src/hooks/useParticipants.ts
@@ -4,16 +4,19 @@ import { useSocketStore, useParticipantsStore } from '@/stores';
 import { ParticipantItem } from '@/types';
 import { convertArrayToObject } from '@/utils';
 
+import { Phases } from '../../../common/phases';
+
 const useParticipants = (roomId: string | null, finishInitialLoading: () => void) => {
   const { socket, connect, disconnect } = useSocketStore();
   const { hostId, setHostId, participants, setParticipants } = useParticipantsStore();
   const [roomExists, setRoomExists] = useState(true);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [phaseOnInitialConnent, setPhaseOnInitialConnent] = useState<Phases | null>(null);
 
   // 참가자 목록 응답 처리
   const handleJoinResponse = (response: {
     status: string;
-    body: { participants: ParticipantItem[]; hostId: string };
+    body: { participants: ParticipantItem[]; hostId: string; phase: Phases };
   }) => {
     setRoomExists(response.status === 'ok');
     if (response.status === 'ok') {
@@ -25,6 +28,7 @@ const useParticipants = (roomId: string | null, finishInitialLoading: () => void
 
       setParticipants(convertArrayToObject(participantsWithIndex));
       setHostId(response.body.hostId);
+      setPhaseOnInitialConnent(response.body.phase);
       finishInitialLoading();
     }
     setCurrentUserId(socket?.id || null);
@@ -89,7 +93,7 @@ const useParticipants = (roomId: string | null, finishInitialLoading: () => void
     }
   }, [socket, roomId, connect, disconnect]);
 
-  return { participants, hostId, currentUserId, roomExists };
+  return { participants, hostId, currentUserId, roomExists, phaseOnInitialConnent };
 };
 
 export default useParticipants;

--- a/frontend/src/routes/components/room/RoomCreateButton.tsx
+++ b/frontend/src/routes/components/room/RoomCreateButton.tsx
@@ -20,12 +20,14 @@ const RoomCreateButton = () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
-        }
+        },
+        credentials: 'include'
       });
 
       if (response.status === 200) {
-        const roomUrl = new URL(response.url);
-        if (roomUrl) navigate(roomUrl.pathname);
+        const json = await response.json();
+        const roomId = json.roomId;
+        if (roomId) navigate(`/rooms/${roomId}`);
       } else {
         openToast({ text: '서버와 통신 중 에러가 발생했습니다!', type: 'error' });
       }

--- a/frontend/src/routes/components/room/UserProfile.tsx
+++ b/frontend/src/routes/components/room/UserProfile.tsx
@@ -86,7 +86,7 @@ const profileStyle = (x: number, y: number, shortRadius: number, longRadius: num
   transition: opacity 0.5s ease-in-out;
   ${flexStyle(10, 'column', 'center', 'center')};
 
-  @media (min-height: 768px) and (max-height: 1200px) {
+  @media (max-height: 1200px) {
     transform: translate(-50%, 50%) scale(0.8);
   }
 `;

--- a/frontend/src/routes/layouts/Room.tsx
+++ b/frontend/src/routes/layouts/Room.tsx
@@ -26,7 +26,10 @@ const RoomLayout = () => {
   const params = useParams();
   const locaton = useLocation();
 
-  const { participants, hostId, currentUserId, roomExists } = useParticipants(roomId, finishInitialLoading);
+  const { participants, hostId, currentUserId, roomExists, phaseOnInitialConnent } = useParticipants(
+    roomId,
+    finishInitialLoading
+  );
   const { radius, setRadius, increaseRadius } = useRadiusStore();
   useCheckRoomAccess();
 
@@ -79,11 +82,11 @@ const RoomLayout = () => {
 
   if (!roomExists) showBoundary(new Error(roomError.RoomNotFound));
 
-  // URL이 정확히 /rooms/:roomId 인 경우 join 페이지로 이동
+  // 서버로부터 받은 현재 Phase에 해당하는 페이지로 이동
   useEffect(() => {
     if (!initialLoading) {
-      if (location.pathname.endsWith(params.roomId)) {
-        navigate('join', { replace: true });
+      if (location.pathname.endsWith(params.roomId) && phaseOnInitialConnent !== null) {
+        navigate(phaseOnInitialConnent, { replace: true });
       }
     }
   }, [initialLoading, params.roomId, locaton.pathname, navigate]);

--- a/frontend/src/routes/pages/ContentShare.tsx
+++ b/frontend/src/routes/pages/ContentShare.tsx
@@ -97,7 +97,7 @@ const ContentSharePhaseViewStyle = css([
     borderRadius: 24,
     transform: 'scale(1)',
 
-    '@media (min-height: 768px) and (max-height: 1200px)': {
+    '@media (max-height: 1200px)': {
       transform: 'scale(0.7)'
     }
   },

--- a/frontend/src/routes/pages/ContentShare.tsx
+++ b/frontend/src/routes/pages/ContentShare.tsx
@@ -1,23 +1,28 @@
 import { css } from '@emotion/react';
 import { useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import StopIcon from '@/assets/icons/stop.svg?react';
 import { useToast } from '@/hooks';
 import { sendShareStopRequest } from '@/services';
 import { useParticipantsStore, useSocketStore } from '@/stores';
 import { flexStyle, Variables } from '@/styles';
-import { Content, NextContentResponse, WaitingQueueResponse } from '@/types';
+import { CommonResult, Content, NextContentResponse, WaitingQueueResponse } from '@/types';
+import { ContentShareProgressOnRefresh } from '@/types/response';
 
 import { ContentPresentSection, WaitingListEmpty, WaitingListInfo } from '../components/content-share/index';
 
 const ContentSharePhaseView = () => {
   const { socket, connect } = useSocketStore();
   const { openToast } = useToast();
-  const { hostId } = useParticipantsStore();
+  const { hostId, setParticipants } = useParticipantsStore();
   const [currentContent, setCurrentContent] = useState<Content | null>(null);
   const [numberOfWaiters, setNumberOfWaiters] = useState(0);
 
   const prevVolumeRef = useRef<number | null>(null);
+
+  const location = useLocation();
+  const { navigatedFromPreviousPhase } = location.state || { navigatedFromPreviousPhase: false };
 
   const stopSharing = async () => {
     try {
@@ -50,6 +55,37 @@ const ContentSharePhaseView = () => {
       });
 
       socket.on('share:interest:add', (response: WaitingQueueResponse) => setNumberOfWaiters(response.nowQueueSize));
+
+      //// 재접속 로직 ////
+      // (재접속한 경우에만 실행됨) 통계결과 표시
+      socket.on('empathy:result', (response: CommonResult) => {
+        Object.entries(response).forEach(([userId, array]) => {
+          setParticipants((prev) => ({ ...prev, [userId]: { ...prev[userId], keywords: array } }));
+        });
+      });
+
+      // (재접속한 경우에만 실행됨) 공유 컨텐츠 정보 표시
+      socket.on('share:interest:progress', (response: ContentShareProgressOnRefresh) => {
+        const { content, nowQueueSize } = response;
+
+        setCurrentContent(
+          content !== null
+            ? {
+                sharerSocketId: content.participantId,
+                type: content.resourceType,
+                resourceURL: content.resourceUrl
+              }
+            : null
+        );
+
+        setNumberOfWaiters(nowQueueSize);
+      });
+
+      // 재접속한 경우라고 판단되면 통계 결과 및 컨텐츠 공유 상황 요청
+      if (socket && !navigatedFromPreviousPhase) {
+        socket.emit('client:request:statistics');
+        socket.emit('client:request:sharing-content');
+      }
     } else {
       connect();
     }
@@ -58,6 +94,8 @@ const ContentSharePhaseView = () => {
       if (socket) {
         socket.off('share:interest:broadcast');
         socket.off('share:interest:add');
+        socket.off('client:request:statistics');
+        socket.off('client:request:sharing-content');
       }
     };
   }, [socket, connect]);

--- a/frontend/src/routes/pages/Join.tsx
+++ b/frontend/src/routes/pages/Join.tsx
@@ -16,7 +16,7 @@ const JoinPhaseView = () => {
   useEffect(() => {
     socket.on('host:start:ack', (response: { status: string; message: string }) => {
       if (response.status === 'ready') {
-        navigate(`/rooms/${params.roomId}/questions`);
+        navigate(`/rooms/${params.roomId}/questions`, { state: { navigatedFromPreviousPhase: true } });
       }
     });
 

--- a/frontend/src/routes/pages/QnA.tsx
+++ b/frontend/src/routes/pages/QnA.tsx
@@ -1,6 +1,6 @@
 import { css, keyframes } from '@emotion/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import ClockIcon from '@/assets/icons/clock.svg?react';
 import { MAX_LONG_RADIUS } from '@/constants/radius';
@@ -29,6 +29,8 @@ const QnAPhaseView = () => {
 
   const navigate = useNavigate();
   const params = useParams();
+  const location = useLocation();
+  const { navigatedFromPreviousPhase } = location.state || { navigatedFromPreviousPhase: false };
 
   const updateSelectedKeywords = useCallback(
     (keyword: string, type: 'add' | 'delete') => {
@@ -101,6 +103,11 @@ const QnAPhaseView = () => {
           setInitialTimeLeft(firstQuestionTimeLeft);
         }
       });
+    }
+
+    // 재접속한 경우라고 판단되면 질문 리스트 요청
+    if (socket && !navigatedFromPreviousPhase) {
+      socket.emit('client:request:questions');
     }
   }, [socket, setQuestions]);
 

--- a/frontend/src/routes/pages/QnA.tsx
+++ b/frontend/src/routes/pages/QnA.tsx
@@ -87,7 +87,21 @@ const QnAPhaseView = () => {
       socket.on('empathy:start', (response: { questions: Question[] }) => {
         setQuestions(response.questions);
         if (response.questions.length > 0) {
-          const firstQuestionTimeLeft = getRemainingSeconds(new Date(response.questions[0].expirationTime), new Date());
+          // 현재 시각에 표시되어야 하는 순서의 질문부터 시작
+          const now = new Date();
+          const firstQuestionIndex = response.questions.findIndex(
+            (question) => new Date(question.expirationTime) > now
+          );
+          // QnA가 이미 끝난 시간인 경우 통계 페이지로 이동
+          if (firstQuestionIndex === -1) {
+            navigate(`/rooms/${params.roomId}/statistics`);
+            return;
+          }
+          const firstQuestionTimeLeft = getRemainingSeconds(
+            new Date(response.questions[firstQuestionIndex].expirationTime),
+            new Date()
+          );
+          setCurrentQuestionIndex(firstQuestionIndex);
           setTimeLeft(firstQuestionTimeLeft);
           setInitialTimeLeft(firstQuestionTimeLeft);
         }

--- a/frontend/src/routes/pages/QnA.tsx
+++ b/frontend/src/routes/pages/QnA.tsx
@@ -92,11 +92,6 @@ const QnAPhaseView = () => {
           const firstQuestionIndex = response.questions.findIndex(
             (question) => new Date(question.expirationTime) > now
           );
-          // QnA가 이미 끝난 시간인 경우 통계 페이지로 이동
-          if (firstQuestionIndex === -1) {
-            navigate(`/rooms/${params.roomId}/statistics`);
-            return;
-          }
           const firstQuestionTimeLeft = getRemainingSeconds(
             new Date(response.questions[firstQuestionIndex].expirationTime),
             new Date()
@@ -121,7 +116,7 @@ const QnAPhaseView = () => {
       timerWorker.current?.postMessage({ action: 'stop' }); // 타이머 중지
 
       if (questions.length > 0) {
-        navigate(`/rooms/${params.roomId}/statistics`);
+        navigate(`/rooms/${params.roomId}/statistics`, { state: { navigatedFromPreviousPhase: true } });
       }
     }
 

--- a/frontend/src/routes/pages/Statistics.tsx
+++ b/frontend/src/routes/pages/Statistics.tsx
@@ -1,6 +1,6 @@
 import { css, keyframes } from '@emotion/react';
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { useToast } from '@/hooks';
 import LoadingPage from '@/routes/pages/LoadingPage';
@@ -17,6 +17,8 @@ const StatisticsPhaseView = () => {
   const [isFadingOut, setIsFadingOut] = useState(false);
   const navigate = useNavigate();
   const params = useParams();
+  const location = useLocation();
+  const { navigatedFromPreviousPhase } = location.state || { navigatedFromPreviousPhase: false };
 
   const handleResult = (response: CommonResult) => {
     if (response) {
@@ -40,6 +42,11 @@ const StatisticsPhaseView = () => {
 
   useEffect(() => {
     socket.on('empathy:result', handleResult);
+
+    // 재접속한 경우라고 판단되면 통계 요청
+    if (socket && !navigatedFromPreviousPhase) {
+      socket.emit('client:request:statistics');
+    }
     return () => {
       socket.off('empathy:result', handleResult);
     };

--- a/frontend/src/routes/pages/Statistics.tsx
+++ b/frontend/src/routes/pages/Statistics.tsx
@@ -30,7 +30,7 @@ const StatisticsPhaseView = () => {
       setTimeout(() => {
         setIsFadingOut(true);
         setTimeout(() => {
-          navigate(`/rooms/${params.roomId}/content-share`);
+          navigate(`/rooms/${params.roomId}/content-share`, { state: { navigatedFromPreviousPhase: true } });
         }, 1000);
       }, 2000);
     } else {

--- a/frontend/src/stores/socket.ts
+++ b/frontend/src/stores/socket.ts
@@ -13,7 +13,9 @@ export const useSocketStore = create<SocketStore>((set) => ({
   socket: null,
 
   connect: () => {
-    const socketInstance = io(config.SOCKET_SERVER_URL);
+    const socketInstance = io(config.SOCKET_SERVER_URL, {
+      withCredentials: true
+    });
     set({ socket: socketInstance });
   },
 

--- a/frontend/src/types/response.ts
+++ b/frontend/src/types/response.ts
@@ -22,6 +22,11 @@ export interface NextContentResponse {
   nowQueueSize: number;
 }
 
+export interface ContentShareProgressOnRefresh {
+  content: NextContentResponse | null;
+  nowQueueSize: number;
+}
+
 export type YoutubeRequestType = 'PLAY' | 'STOP' | 'TIMELINE' | 'SPEED' | 'DRAGGING';
 
 export interface InterestYoutubeResponse {


### PR DESCRIPTION
# ✅ 주요 작업
- [지난번에 이야기한 재접속 API](https://lime-mall-d34.notion.site/Reconnect-on-refresh-API-2e344a5f635249b4b3499c42b7207202?pvs=4)를 기반으로 각 페이지에서 유저가 재접속했다고 판단한 경우 필요한 데이터를 재요청하고 받아서 처리하는 템플릿 로직을 구현하였습니다.
- 방 생성 응답 처리 및 이동 로직 수정

# 📚 학습 키워드
- [useNavigate state](https://velog.io/@gin2808/React-useNavigate%EB%A1%9C-state-%EB%84%98%EA%B8%B0%EA%B8%B0)
- enum type

# 💭 고민과 해결과정
## 방 입장 시 진행중인 Phase에 해당하는 페이지로 이동
- join 이벤트로 방에 입장할 때 응답으로 전달받을 `현재 Phase`는 BE/FE 간 네이밍 혼동이 없도록 프로젝트 최상단 `common/phases.ts` 파일에 아래와 같이 정의하였습니다.
```ts
/** common/phases.ts */

// enum value: URL Pathname
export enum Phases {
  Join = "join",
  QnA = "questions",
  Statistics = "statistics",
  ContentShare = "content-share",
}

export type PhaseKeys = keyof typeof Phases;
// "Join" | "QnA" | "Statistics" | "ContentShare"
```
BE에서는 `join` 이벤트에 대한 응답으로 phase 필드에 `Phases.Join`과 같이 값을 지정합니다.
```ts
{
  status: 'ok',
  body: {
	  participants: [
	    {
	      id: string,
	      nickname: string,
	    },
	    ...
	  ],
	  hostId: string,
	  phase: Phases, // Phases enum 값 중 하나
  },
}
```
FE에서는 서버로부터 받은 현재 Phase에 해당하는 페이지로 이동합니다.
```ts
/** useParticipants.ts */
const [phaseOnInitialConnent, setPhaseOnInitialConnent] = useState<Phases | null>(null);

// 참가자 목록 응답 처리
  const handleJoinResponse = (response: {
    status: string;
    body: { participants: ParticipantItem[]; hostId: string; phase: Phases };
  }) => {
      // ...
      setPhaseOnInitialConnent(response.body.phase);
    }
  };

/** Room.tsx */
// 서버로부터 받은 현재 Phase에 해당하는 페이지로 이동
  useEffect(() => {
    if (!initialLoading) {
      if (location.pathname.endsWith(params.roomId) && phaseOnInitialConnent !== null) {
        navigate(phaseOnInitialConnent, { replace: true });
      }
    }
  }, [initialLoading, params.roomId, locaton.pathname, navigate]);
```

## 재접속(또는 진행 도중 접속) 판별 (`useNaviagte state` 활용)
특정 페이지에서 새로고침(Refresh)하거나, 이미 아이스브레이킹이 진행된 이후에 접속했는지 확인하기 위해, `Phase A -> Phase B` 페이지로 정상적으로(도중에 나가는 등의 action 없이) 이동하는 경우 이동 중에 `navigatedFromPreviousPhase` 플래그를 `state`로 전달합니다.
```ts
/** Join.tsx */
// 예시) 호스트의 QnA 시작에 대한 응답 메시지가 클라이언트에 전달되어 이동하는 경우
socket.on('host:start:ack', (response: { status: string; message: string }) => {
      if (response.status === 'ready') {
        navigate(`/rooms/${params.roomId}/questions`, { state: { navigatedFromPreviousPhase: true } });
      }
    });
```
이동된 Phase의 페이지에서는 `navigatedFromPreviousPhase` 플래그가 true인지 여부를 확인하고, false인 경우 재접속 또는 진행 도중 접속으로 판단하고 필요한 데이터를 요청하는 소켓 이벤트를 emit합니다.
```ts
/** QnA.tsx */
const location = useLocation();
const { navigatedFromPreviousPhase } = location.state || { navigatedFromPreviousPhase: false };

useEffect(() => {
   // ...

    if (socket) {
      // 서버로부터 받은  질문 리스트 처리
      socket.on('empathy:start', (response: { questions: Question[] }) => {
        setQuestions(response.questions);
        if (response.questions.length > 0) {
          // 현재 시각에 표시되어야 하는 순서의 질문부터 시작
          const now = new Date();
          const firstQuestionIndex = response.questions.findIndex(
            (question) => new Date(question.expirationTime) > now
          );
          const firstQuestionTimeLeft = getRemainingSeconds(
            new Date(response.questions[firstQuestionIndex].expirationTime),
            new Date()
          );
          setCurrentQuestionIndex(firstQuestionIndex);
          setTimeLeft(firstQuestionTimeLeft);
          setInitialTimeLeft(firstQuestionTimeLeft);
        }
      });
    }

    // 재접속한 경우라고 판단되면 질문 리스트 요청
    if (socket && !navigatedFromPreviousPhase) {
      socket.emit('client:request:questions');
    }
  }, [socket, setQuestions]);
```

# 📌 이슈 사항
