### PR TITLE
타이머가 gpu 가속 속성을 사용하도록 개선

### DIFF
--- a/frontend/src/puppeteer/wordcloud.js
+++ b/frontend/src/puppeteer/wordcloud.js
@@ -108,6 +108,7 @@ async function startGame(hostPage) {
 async function waitForInputField(pageList) {
   for (let i = 0; i < pageList.length; i++) {
     const page = pageList[i];
+    await page.bringToFront();
     await page.waitForFunction(() => {
       return document.body.querySelector('input');
     });
@@ -116,6 +117,8 @@ async function waitForInputField(pageList) {
 
 async function startTracing(pageList) {
   const hostPage = pageList[0];
+  await hostPage.bringToFront();
+
   const inputSelector = 'input[placeholder="답변을 입력해주세요"]';
 
   let intervalCntList = [];

--- a/frontend/src/routes/pages/QnA.tsx
+++ b/frontend/src/routes/pages/QnA.tsx
@@ -157,12 +157,14 @@ const QnAPhaseView = () => {
               />
               <div css={progressWrapperStyle}>
                 <ClockIcon width="35px" height="35px" fill="#000" />
-                <progress
-                  id="progress"
-                  value={initialTimeLeft > 0 ? (timeLeft / initialTimeLeft) * 100 : 100}
-                  max={100}
-                  css={progressBarStyle}
-                />
+                <div css={progressBarStyle}>
+                  <div
+                    style={{
+                      transform: `scaleX(${initialTimeLeft > 0 ? timeLeft / initialTimeLeft : 1})`
+                    }}
+                    css={progressBarValueStyle}
+                  ></div>
+                </div>
               </div>
             </div>
           )}
@@ -217,19 +219,14 @@ const progressBarStyle = css`
   width: 100%;
   height: 12px;
   border-radius: 50px;
-  background-color: #eee;
+  background-color: ${Variables.colors.surface_alt};
+  overflow: hidden;
+`;
 
-  ::-webkit-progress-bar {
-    background-color: ${Variables.colors.surface_alt};
-    border-radius: 50px;
-    height: 12px;
-    overflow: hidden;
-  }
-
-  ::-webkit-progress-value {
-    background-color: ${Variables.colors.surface_strong};
-    border-radius: 50px;
-    height: 12px;
-    transition: width 1s linear;
-  }
+const progressBarValueStyle = css`
+  background-color: ${Variables.colors.surface_strong};
+  border-radius: 50px;
+  height: 12px;
+  transition: transform 1s linear;
+  transform-origin: left;
 `;


### PR DESCRIPTION
# ✅ 주요 작업
- [x] 타이머가 width 대신 transform을 통해 변하도록 수정
- [x] puppeteer 성능 측정 프로세스 프론트엔드 구조 변경에 따라 오류가 발생하지 않도록 수정

## 개선 결과
### 개선 이전
![{045718F3-36A6-4140-838E-1FA07DE90EC6}](https://github.com/user-attachments/assets/ccb88fc7-66ad-4275-8d7d-ed2f6ffe2ac6)

### 개선 이후
![{FD2843B6-2A63-40F1-B99E-0CF4E14AA64B}](https://github.com/user-attachments/assets/981946e9-4d88-4522-a39c-824b281f1702)

### 성능 개선 전후 비교

| 작업 단계   | 개선 전 | 개선 후 | 변화량 | 비율 변화 (%) |
|------------|---------|---------|---------|--------------|
| **Rendering**  | 1,121 ms | 872 ms | -249 ms | -22.21% |
| **Scripting**  | 579 ms | 551 ms | -28 ms | -4.84% |
| **System**     | 596 ms | 510 ms | -86 ms | -14.43% |
| **Painting**   | 241 ms | 149 ms | -92 ms | -38.17% |


# 📚 학습 키워드
GPU 가속 속성

# 💭 고민과 해결과정
### 타이머 개선
width를 사용해 타이머가 움직이도록 할 경우, 매번 레이아웃부터 렌더링 작업이 실행되므로 비효율적이고 CPU에 부담을 주게 됩니다. 반면 GPU 가속 속성을 사용할 경우 CPU와 메인 스레드에 주어지는 부담을 줄일 수 있습니다. 많은 렌더링 작업이 필요한 서비스이므로, CPU에 주는 부담을 줄이기 위해 GPU 가속 속성을 이용하도록 개선했습니다.

### puppeteer 버그 수정
이유는 명확히 알 수는 없으나, 프론트엔드 구조를 라우터로 개선한 이후 포커싱을 한 번씩 주지 않으면 input 탭을 찾아 기다리는 함수가 정상 작동하지 않는 문제가 발생했습니다. 찾기 전 각 탭에 포커싱을 주도록 변경해 버그를 수정했습니다.


# 📌 이슈 사항
X